### PR TITLE
Update Address.php to include province

### DIFF
--- a/src/Models/Address.php
+++ b/src/Models/Address.php
@@ -33,6 +33,11 @@ class Address
     private $coordinates;
 
     /**
+     * @var null|string
+     */
+    private $province;
+
+    /**
      * Address constructor.
      * @param Location $location
      */
@@ -43,6 +48,7 @@ class Address
         $this->postalCode = $location->getPostalCode();
         $this->city = $location->getLocality();
         $this->coordinates = $location->getCoordinates();
+        $this->province = count($location->getAdminLevels()) > 0 ? $location->getAdminLevels()->get('1')->getName() : null;
     }
 
     public static function fromLocation(Location $location)
@@ -88,5 +94,13 @@ class Address
     public function getCoordinates(): ?Coordinates
     {
         return $this->coordinates;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getProvince(): ?string
+    {
+        return $this->province;
     }
 }

--- a/tests/Feature/PostalCodeLookupServiceTest.php
+++ b/tests/Feature/PostalCodeLookupServiceTest.php
@@ -22,6 +22,7 @@ class PostalCodeLookupServiceTest extends TestCase
         $this->assertNotNull($result->getStreet());
         $this->assertNotNull($result->getCity());
         $this->assertNotNull($result->getCoordinates());
+        $this->assertNotNull($result->getProvince());
     }
 
     public function testValidAndFormattedPostalCodeWithHouseNumberLookupReturnsValidValues()
@@ -40,6 +41,7 @@ class PostalCodeLookupServiceTest extends TestCase
         $this->assertNotNull($result->getStreet());
         $this->assertNotNull($result->getCity());
         $this->assertNotNull($result->getCoordinates());
+        $this->assertNotNull($result->getProvince());
     }
 
     public function testValidAndFormattedPostalCodeWithHouseNumberAndExtensionLookupReturnsValidValues()
@@ -58,6 +60,7 @@ class PostalCodeLookupServiceTest extends TestCase
         $this->assertNotNull($result->getStreet());
         $this->assertNotNull($result->getCity());
         $this->assertNotNull($result->getCoordinates());
+        $this->assertNotNull($result->getProvince());
     }
 
     public function testValidAndUnformattedPostalCodeLookupReturnsValidValues()
@@ -75,6 +78,7 @@ class PostalCodeLookupServiceTest extends TestCase
         $this->assertNotNull($result->getStreet());
         $this->assertNotNull($result->getCity());
         $this->assertNotNull($result->getCoordinates());
+        $this->assertNotNull($result->getProvince());
     }
 
     public function testValidAndUnformattedPostalCodeWithHouseNumberLookupReturnsValidValues()
@@ -95,6 +99,7 @@ class PostalCodeLookupServiceTest extends TestCase
         $this->assertNotNull($result->getStreet());
         $this->assertNotNull($result->getCity());
         $this->assertNotNull($result->getCoordinates());
+        $this->assertNotNull($result->getProvince());
     }
 
     public function testValidAndUnformattedPostalCodeWithHouseNumberAndExtensionLookupReturnsValidValues()
@@ -115,6 +120,7 @@ class PostalCodeLookupServiceTest extends TestCase
         $this->assertNotNull($result->getStreet());
         $this->assertNotNull($result->getCity());
         $this->assertNotNull($result->getCoordinates());
+        $this->assertNotNull($result->getProvince());
     }
 
     public function testInvalidPostalCodeLookupReturnsNull()


### PR DESCRIPTION
Hey guys,

I've been using this package for years, but I eventually copied y'alls work for my own version that also included the coordinates AND the province.

However, i much prefer user a publicly maintained package over my own 5 year old code.
Since i saw that coordinates are added, i'm using it in a new project, however I yet again need the province for an interactive map.
Hence I made this PR: added the province to the address object. 

🫶🫶🫶

